### PR TITLE
修复微博内容展示为true的问题

### DIFF
--- a/extension/content/rule/feeds/content.js
+++ b/extension/content/rule/feeds/content.js
@@ -175,7 +175,7 @@ span.yawf-feed-screen-name { font-weight: bold; }
         const vueSetup = yawf.vueSetup;
 
         const expandLongTextContent = function (vm) {
-          vm.$set(vm.data, 'text_expand', vm.showText);
+          vm.$set(vm.data, 'text_expand', vm.text);
           vm.$http = Object.create(vm.$http);
           vm.$http.get = (function (get) {
             return async function (...args) {
@@ -205,15 +205,15 @@ span.yawf-feed-screen-name { font-weight: bold; }
             const unwatch = vm.$watch(function () { return this.data.longTextContent; }, function () {
               if (!vm.data.longTextContent) return;
               unwatch();
-              vm.showText = vm.data.longTextContent;
-              vm.$emit('updateText', vm.showText);
+              vm.text = vm.data.longTextContent;
+              vm.$emit('updateText', vm.text);
             });
           } else {
             const expand = '<span class="expand">展开</span>';
             const wordTip = `展开（约 ${Math.ceil(len / 10) * 10} 字）`;
             vm.data.text_expand = vm.data.text_expand.replace(expand, () => expand.replace('展开', wordTip));
-            vm.showText = vm.data.text_expand;
-            vm.$emit('updateText', vm.showText);
+            vm.text = vm.data.text_expand;
+            vm.$emit('updateText', vm.text);
           }
         };
 


### PR DESCRIPTION
vm.showText现在的值变成了一个true，导致自动展开微博功能开启时会把这个true当成微博内容进行处理，最终效果为微博内容无法查看，只显示一个true，替换为vm.text可以解决该问题
![image](https://github.com/user-attachments/assets/c652e2d6-f44a-405d-ad7c-36939ce8a209)
